### PR TITLE
Create days on initial creation

### DIFF
--- a/src/app/components/SearchBar.jsx
+++ b/src/app/components/SearchBar.jsx
@@ -50,7 +50,9 @@ const SearchBar = ({ className, setVisibleEvents, visibleEvents, dayEvent={}, ne
   const onPlaceChanged = place => {
     if (place) {
       setInputValue(place.formatted_address || place.name);
-      !setAutoCompleted ?? setAutoCompleted(true);
+      if(setAutoCompleted) {
+        setAutoCompleted(true);
+      }
       if (newTripCreation) {
       setTripData((prev) => ({
         ...prev,
@@ -70,7 +72,9 @@ const SearchBar = ({ className, setVisibleEvents, visibleEvents, dayEvent={}, ne
 
   const handleInputChange = event => {
     setInputValue(event.target.value);
-    !setAutoCompleted ?? setAutoCompleted(false);
+    if (setAutoCompleted) {
+      setAutoCompleted(false);
+    }
   };
 
   return (

--- a/src/app/plan/[encodedUrl]/page.jsx
+++ b/src/app/plan/[encodedUrl]/page.jsx
@@ -77,6 +77,7 @@ const loadTripDetails = async (url, setTripData, setDaysExist) => {
   }
 };
 
+// unused for now until we figure out how to allow for editing/saving w/o db connection
 const createInitialEmptyDays = async (tripData, setTripData) => {
   if (tripData.days.length !== 0) {
     return;
@@ -135,7 +136,7 @@ export default function () {
   }, []);
 
   useEffect(() => {
-    createInitialEmptyDays(tripData, setTripData);
+    //createInitialEmptyDays(tripData, setTripData);
     loadTripDetails(url, setTripData, setDaysExist);
   }, []);
 

--- a/src/app/plan/[encodedUrl]/page.jsx
+++ b/src/app/plan/[encodedUrl]/page.jsx
@@ -77,6 +77,40 @@ const loadTripDetails = async (url, setTripData, setDaysExist) => {
   }
 };
 
+const createInitialEmptyDays = async (tripData, setTripData) => {
+  if (tripData.days.length !== 0) {
+    return;
+  }
+  const days = [];
+
+  const start = new Date(tripData.startDate);
+  const end = new Date(tripData.endDate);
+
+// Calculate the number of days between the start and end dates
+const diffInDays = Math.floor((end - start) / (1000 * 60 * 60 * 24));
+
+// Create an array of day objects based on the difference in days
+for (let i = 0; i <= diffInDays; i++) {
+let day = new Date(start);
+day.setDate(day.getDate() + i);
+
+// Log each day for debugging
+console.log("Day " + i + ":", day);
+
+// Add day with tripId and empty notes
+days.push({ key: i ,date: day.toISOString(), tripId: tripData.tripId, notes: '' });
+}
+
+try {
+  setTripData((prev) => ({
+    ...prev,
+    days: days
+  }));
+} catch (error) {
+  console.error("Error setting initial days:", error);
+}
+};
+
 export default function () {
   const currentUser = useUser();
   const { tripData, setTripData } = useTripData();
@@ -101,9 +135,10 @@ export default function () {
   }, []);
 
   useEffect(() => {
+    createInitialEmptyDays(tripData, setTripData);
     loadTripDetails(url, setTripData, setDaysExist);
-    console.log(tripData);
   }, []);
+
 
   // editting safeguards against non-users/different users
   // useEffect(() => {


### PR DESCRIPTION
- fixed search bar logic error for new trip creation
- added code to populate tripData with empty days on initial trip creation but commented it out until we figure out a solution for the events/days editing after creation